### PR TITLE
MAINT: bump create-pull-request to v6

### DIFF
--- a/.github/workflows/depup.yml
+++ b/.github/workflows/depup.yml
@@ -21,7 +21,7 @@ jobs:
           repo: reviewdog/reviewdog
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           title: "chore(deps): update reviewdog to ${{ steps.depup.outputs.latest }}"


### PR DESCRIPTION
# Changes

MAINT: bump create-pull-request to v6

# Reasons

On forked repositories, `peter-evans/create-pull-request@v6` occurs error with https://github.com/peter-evans/create-pull-request/issues/2790. So, we need to upgrade it.